### PR TITLE
fix broken demo

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { streamText, UIMessage } from "ai";
 import { killDesktop } from "@/lib/e2b/utils";
 import { bashTool, computerTool } from "@/lib/e2b/tool";
-import { prunedMessages } from "@/lib/utils";
+import { getErrorMessage, prunedMessages } from "@/lib/utils";
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 300;
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
     await req.json();
   try {
     const result = streamText({
-      model: anthropic("claude-3-7-sonnet-20250219"), // Using Sonnet for computer use
+      model: anthropic("claude-sonnet-4-20250514"), // Using Claude Sonnet 4 for computer use
       system:
         "You are a helpful assistant with access to a computer. " +
         "Use the computer tool to help the user with their requests. " +
@@ -28,10 +28,9 @@ export async function POST(req: Request) {
 
     // Create response stream
     const response = result.toDataStreamResponse({
-      // @ts-expect-error eheljfe
-      getErrorMessage(error) {
+      getErrorMessage: (error) => {
         console.error(error);
-        return error;
+        return getErrorMessage(error);
       },
     });
 

--- a/lib/e2b/tool.ts
+++ b/lib/e2b/tool.ts
@@ -1,4 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
+import { getErrorMessage } from "@/lib/utils";
 import { getDesktop } from "./utils";
 
 const wait = async (seconds: number) => {
@@ -146,11 +147,7 @@ export const bashTool = (sandboxId?: string) =>
         );
       } catch (error) {
         console.error("Bash command failed:", error);
-        if (error instanceof Error) {
-          return `Error executing command: ${error.message}`;
-        } else {
-          return `Error executing command: ${String(error)}`;
-        }
+        return `Error executing command: ${getErrorMessage(error)}`;
       }
     },
   });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,6 +8,14 @@ export function cn(...inputs: ClassValue[]) {
 
 export const ABORTED = "User aborted";
 
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String(error.message);
+  }
+  return String(error);
+}
+
 export const prunedMessages = (messages: UIMessage[]): UIMessage[] => {
   if (messages.at(-1)?.role === "assistant") {
     return messages;


### PR DESCRIPTION
**Summary**
This PR fixes the broken API that prevents the demo from working.


**Changes**
  1. Fix invalid model name
  Changed claude-3-7-sonnet-20250219 → claude-sonnet-4-20250514

  2. Fix getErrorMessage to return a string
  The AI SDK's data stream protocol requires error messages to be strings
  The original code returned the raw error object, causing client-side parsing errors ("error" parts expect a string value)
  Added a shared getErrorMessage utility in lib/utils.ts that handles:
  Error instances
  Plain objects with a message property (e.g., { type: 'overloaded_error', message: 'Overloaded' })
  Fallback to String(error)

  3. Updated bash tool error handling
  Refactored to use the shared getErrorMessage utility for consistency
